### PR TITLE
hotfix - Netlify Build Error

### DIFF
--- a/blog-config.js
+++ b/blog-config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  siteUrl: '',
+  siteUrl: 'localhost:8000', // Used for sitemap generation
   // Used in manifest.json
   manifestSettings: {
     favicon: './contents/images/favicon.png', // Path is relative to the root

--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -5,7 +5,9 @@ const blogConfig = require('./blog-config');
 const { siteUrl, manifestSettings } = blogConfig;
 
 const config: GatsbyConfig = {
-  siteMetadata: siteUrl ? { siteUrl: siteUrl } : {},
+  siteMetadata: {
+    siteUrl: siteUrl,
+  },
   graphqlTypegen: true,
 
   plugins: [


### PR DESCRIPTION
An error occurs if siteUrl field is empty in the gatsby-config.ts file.